### PR TITLE
Update _common.scss

### DIFF
--- a/gnome-shell/gnome-shell-sass/_common.scss
+++ b/gnome-shell/gnome-shell-sass/_common.scss
@@ -833,6 +833,11 @@ StScrollBar {
         color: transparentize($fg_color,0.85);
         opacity: 0.5;
       }
+      .calendar-week-number {
+        background: none;
+        font-weight: bold;
+        color: $selected_bg_color;
+      }
 
       /* Message list */
       .message-list {


### PR DESCRIPTION
add style for weeknumbers
- to activate: "gsettings set org.gnome.shell.calendar show-weekdate true"
- to deactivate: "gsettings set org.gnome.shell.calendar show-weekdate false"
